### PR TITLE
Add language: generic to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: trusty
 
+language: generic
+
 services:
   - docker
 


### PR DESCRIPTION
The default Travis CI language is ruby, which causes the job to fail.